### PR TITLE
Add optional registry, e.g., for GitHub packages

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Build the plugin
       - name: Build

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,7 +26,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Validate
       - name: Validate

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The Docker build and push can be configured via the following options:
 | Option           | Description                                                                     | Default Value                            |
 |------------------|---------------------------------------------------------------------------------|------------------------------------------|
 | `dockerFilePath` | Path to the Dockerfile used for building the image                              | `""` (defaults to the `rootProject` dir) |
+| `registry`       | Docker registry where the image will be pushed                                  | `"hub.docker.com"` (optional)            |
 | `repository`     | Docker repository where the image will be pushed                                | `""` (required)                          |
 | `platforms`      | List of platforms for multiplatform builds (e.g., `linux/amd64`, `linux/arm64`) | `["linux/amd64"]`                        |
 | `buildArgs`      | Map of build arguments to be passed to the Docker build command                 | `{}` (empty map)                         |
@@ -34,7 +35,7 @@ Docker tasks
 ------------
 dockerBuild  - Builds the Docker image(s) defined in the configuration. Supports multiplatform builds and custom build arguments.
 dockerLogin  - Logs into the Docker registry using the provided username and password from the environment or configuration.
-dockerPush   - Pushes the built Docker image(s) to the specified repository, applying any specified tags and the `latest` tag if enabled.
+dockerPush   - Pushes the built Docker image(s) to the specified registry/repository, applying any specified tags and the `latest` tag if enabled.
 
 ```
 
@@ -63,4 +64,4 @@ Docker authentication can be managed via environment variables:
 - `DOCKER_USERNAME`: Your Docker username
 - `DOCKER_PASSWORD`: Your Docker password
 
-These credentials are automatically picked up by the plugin when pushing images to a repository.
+These credentials are automatically picked up by the plugin when pushing images to a registry/repository.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version("1.9.10")
 }
 
-version = "0.5.0"
+version = "0.6.0"
 group = "com.fussionlabs.gradle"
 
 repositories {

--- a/src/main/kotlin/com/fussionlabs/gradle/docker/Constants.kt
+++ b/src/main/kotlin/com/fussionlabs/gradle/docker/Constants.kt
@@ -8,3 +8,5 @@ const val DOCKER_PLUGIN_BUILDER = "docker-plugin-builder"
 const val DOCKER_LOGIN_TASK = "dockerLogin"
 const val DOCKER_BUILD_TASK = "dockerBuild"
 const val DOCKER_PUSH_TASK = "dockerPush"
+
+const val DOCKER_DEFAULT_REGISTRY = "hub.docker.com"

--- a/src/main/kotlin/com/fussionlabs/gradle/docker/DockerPlugin.kt
+++ b/src/main/kotlin/com/fussionlabs/gradle/docker/DockerPlugin.kt
@@ -37,7 +37,7 @@ class DockerPlugin: Plugin<Project> {
             task.dependsOn(DOCKER_LOGIN_TASK)
             task.pushImage = true
             task.group = DOCKER_PLUGIN_GROUP
-            task.description = "Pushes the built Docker image(s) to the specified repository, applying any specified tags and the `latest` tag if enabled"
+            task.description = "Pushes the built Docker image(s) to the specified registry/repository, applying any specified tags and the `latest` tag if enabled"
 
             if (project.dockerExt.requireBuild) {
                 task.dependsOn("build")
@@ -59,6 +59,10 @@ class DockerPlugin: Plugin<Project> {
         if (extension.dockerFilePath.isEmpty()) {
             logger.warn("No Dockerfile path set, defaulting to project directory: ${project.rootDir.absolutePath}")
             extension.dockerFilePath = project.rootDir.absolutePath
+        }
+
+        if (extension.registry.isEmpty()) {
+            logger.info("No Registry specified, defaulting to Docker Hub ({})", DOCKER_DEFAULT_REGISTRY)
         }
     }
 }

--- a/src/main/kotlin/com/fussionlabs/gradle/docker/DockerPluginExtension.kt
+++ b/src/main/kotlin/com/fussionlabs/gradle/docker/DockerPluginExtension.kt
@@ -2,6 +2,7 @@ package com.fussionlabs.gradle.docker
 
 open class DockerPluginExtension {
     var dockerFilePath = ""
+    var registry = ""
     var repository: String = ""
     var platforms = mutableListOf("linux/amd64")
     var buildArgs = mutableMapOf<String, String>()

--- a/src/main/kotlin/com/fussionlabs/gradle/docker/tasks/DockerLogin.kt
+++ b/src/main/kotlin/com/fussionlabs/gradle/docker/tasks/DockerLogin.kt
@@ -10,6 +10,10 @@ open class DockerLogin: DockerTask() {
         val password = project.dockerExt.password
 
         dockerTaskArgs.addAll(listOf("login", "--username", username, "--password-stdin"))
+        project.dockerExt.registry.takeIf { it.isNotEmpty() }?.let { registry ->
+            dockerTaskArgs.add(registry)
+        }
+
         standardInput = ByteArrayInputStream(password.toByteArray())
 
         super.exec()

--- a/src/main/kotlin/com/fussionlabs/gradle/docker/utils/PluginUtils.kt
+++ b/src/main/kotlin/com/fussionlabs/gradle/docker/utils/PluginUtils.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Project
 import org.gradle.api.logging.Logging
 import java.io.File
 import java.util.concurrent.TimeUnit
+import com.fussionlabs.gradle.docker.DOCKER_DEFAULT_REGISTRY
 
 object PluginUtils {
     val logger = Logging.getLogger(PluginUtils::class.java)
@@ -32,7 +33,12 @@ object PluginUtils {
 
     fun getImageTags(dockerExt: DockerPluginExtension): List<String> {
         val imageTags = mutableListOf<String>()
-        val repository = dockerExt.repository
+        val repository = if (dockerExt.registry.isNotEmpty() && dockerExt.registry != DOCKER_DEFAULT_REGISTRY) {
+            "${dockerExt.registry}/${dockerExt.repository}"
+        } else {
+            dockerExt.repository
+        }
+        logger.debug("Using full registry/repository '{}'", repository)
 
         dockerExt.tags.forEach { tag ->
             imageTags.add("$repository:$tag")


### PR DESCRIPTION
By default, the plugin only used hub.docker.com as registry. If the user sets another registry, it needs to be set in front of the image names or tags and be used for the mandatory login before pushing.

Note that there is no test case for this as it requires a registry, credentials and perhaps some house keeping to get rid of intermediate images. However, I have added a local build of the plugin to my own repository and used it successfully to publish a multi-platform Docker manifest (containing images for amd64 and arm64): https://github.com/aim42/htmlSanityCheck/actions/runs/13502446424/job/37724482669